### PR TITLE
CFP Submission Update Method

### DIFF
--- a/conferences/getpaper.go
+++ b/conferences/getpaper.go
@@ -12,7 +12,7 @@ type GetPaperParams struct {
 	PaperID uint32
 }
 
-// GetPaperResponse defines the output returned by the GetPaperResponse API method
+// GetPaperResponse defines the output returned by the GetPaper API method
 type GetPaperResponse struct {
 	Paper Paper
 }

--- a/conferences/papersubmission_test.go
+++ b/conferences/papersubmission_test.go
@@ -30,7 +30,7 @@ func TestAddPaperRoundTrip(t *testing.T) {
 		result, err := GetPaper(ctx, &GetPaperParams{PaperID: response.PaperID})
 
 		if err != nil {
-			t.Fatalf("undexpected database error: %v", err)
+			t.Fatalf("unexpected database error: %v", err)
 		}
 
 		if result.Paper.UserID != paper.UserID {

--- a/conferences/ticketing_processing_test.go
+++ b/conferences/ticketing_processing_test.go
@@ -128,6 +128,7 @@ func Test_claimSlots(t *testing.T) {
 					t.Fatalf("retrieving new ticket IDs %v", err)
 					return
 				}
+				defer rows.Close()
 
 				for i := len(tt.want[attendee]) - 1; i >= 0; i-- {
 					if !rows.Next() {
@@ -140,7 +141,7 @@ func Test_claimSlots(t *testing.T) {
 						return
 					}
 				}
-				rows.Close()
+
 				if !reflect.DeepEqual(got, tt.want[attendee]) {
 					t.Errorf("claimSlots() = %v, want %v", got, tt.want[attendee])
 				}

--- a/conferences/ticketing_storage.go
+++ b/conferences/ticketing_storage.go
@@ -83,7 +83,7 @@ func readAttendee(ctx context.Context, tx *sqldb.Tx, email string, id int64) (*A
 
 	claims := []SlotClaim{}
 
-	sqlStatement = `SELECT id, ticket_id, redeemed FROM slot_claim 
+	sqlStatement = `SELECT id, ticket_id, redeemed FROM slot_claim
 	WHERE attendee_id = $1`
 	sqlArgs = []interface{}{results.ID}
 	var rows *sqldb.Rows
@@ -96,6 +96,9 @@ func readAttendee(ctx context.Context, tx *sqldb.Tx, email string, id int64) (*A
 	if err != nil {
 		return nil, fmt.Errorf("querying claims for attendee: %w", err)
 	}
+
+	defer rows.Close()
+
 	for rows.Next() {
 		claim := SlotClaim{}
 		err := rows.Scan(&claim.ID, &claim.TicketID, &claim.Redeemed)
@@ -112,7 +115,7 @@ func readAttendee(ctx context.Context, tx *sqldb.Tx, email string, id int64) (*A
 // createConferenceSlot saves a slot in the database.
 func createConferenceSlot(ctx context.Context, tx *sqldb.Tx, cslot *ConferenceSlot, conferenceID int64) (*ConferenceSlot, error) {
 	var sqlStatement = `INSERT INTO conference_slot (conference_id, name, description, cost, capacity, start_date, end_date, purchaseable_from, purchaseable_until, available_to_public)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) 
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	RETURNING conference_id, name, description, cost, capacity, start_date, end_date, purchaseable_from, purchaseable_until, available_to_public`
 	var sqlArgs = []interface{}{
 		conferenceID,
@@ -164,7 +167,7 @@ func readConferenceSlotByID(ctx context.Context, tx *sqldb.Tx, id uint64, loadDe
 	results := ConferenceSlot{}
 	var row *sqldb.Row
 	sqlStatement := `SELECT id, name, description, cost, capacity, start_date, end_date, purchaseable_from, purchaseable_until, available_to_public, COALESCE(depends_on, 0)
-	FROM conference_slot 
+	FROM conference_slot
 	WHERE id = $1`
 	sqlArgs := []interface{}{id}
 	if tx != nil {
@@ -197,9 +200,9 @@ func readConferenceSlotByID(ctx context.Context, tx *sqldb.Tx, id uint64, loadDe
 // updateConferenceSlot updates conference slot fields from the passed instance
 func updateConferenceSlot(ctx context.Context, tx *sqldb.Tx, cslot *ConferenceSlot, conferenceID int64) error {
 	// Regular update
-	var sqlStatement = `UPDATE conference_slot 
-	SET conference_id = $1, name = $2, description = $3, cost =$4, capacity=$5, 
-	start_date = $6, end_date = $7, purchaseable_from = $8, purchaseable_until = $9, 
+	var sqlStatement = `UPDATE conference_slot
+	SET conference_id = $1, name = $2, description = $3, cost =$4, capacity=$5,
+	start_date = $6, end_date = $7, purchaseable_from = $8, purchaseable_until = $9,
 	available_to_public $10
 	WHERE id = $11`
 	var args = []interface{}{

--- a/conferences/updatepaper.go
+++ b/conferences/updatepaper.go
@@ -1,0 +1,64 @@
+package conferences
+
+import (
+	"context"
+	"fmt"
+
+	"encore.dev/storage/sqldb"
+)
+
+// UpdatePaperParams defines the inputs used by the GetPaper API method
+type UpdatePaperParams struct {
+	Paper *Paper
+}
+
+// UpdatePaperResponse defines the output received by the UpdatePaper API method
+type UpdatePaperResponse struct {
+	Paper Paper
+}
+
+// UpdatePaper updates a paper submission for a specific paper id
+// encore:api public
+func UpdatePaper(ctx context.Context, params *UpdatePaperParams) (*UpdatePaperResponse, error) {
+
+	row := sqldb.QueryRow(ctx,
+		`
+		UPDATE paper_submission
+		SET title = $1,
+			elevator_pitch = $2,
+			description = $3,
+			notes = $4
+		WHERE id = $5
+		RETURNING id,
+			user_id,
+			conference_id,
+			title,
+			elevator_pitch,
+			description,
+			notes
+	`,
+		params.Paper.Title,
+		params.Paper.ElevatorPitch,
+		params.Paper.Description,
+		params.Paper.Notes,
+		params.Paper.ID,
+	)
+
+	var paper Paper
+
+	err := row.Scan(
+		&paper.ID,
+		&paper.UserID,
+		&paper.ConferenceID,
+		&paper.Title,
+		&paper.ElevatorPitch,
+		&paper.Description,
+		&paper.Notes,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to update paper submission: %w", err)
+	}
+
+	return &UpdatePaperResponse{Paper: paper}, nil
+}

--- a/conferences/updatepaper_test.go
+++ b/conferences/updatepaper_test.go
@@ -1,0 +1,66 @@
+package conferences
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpdatePaperSubmission(t *testing.T) {
+
+	t.Run("checks that a user can update all fields in their proposal", func(t *testing.T) {
+
+		originalPaper := &Paper{
+			UserID:        "test_user_1",
+			ConferenceID:  1,
+			Title:         "Test title",
+			ElevatorPitch: "Elevating elevator pitch",
+			Description:   "Descriptive description",
+			Notes:         "Notable Notes",
+		}
+
+		ctx := context.Background()
+		response, err := AddPaper(ctx, &AddPaperParams{
+			Paper: originalPaper,
+		},
+		)
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		updatedPaper := &Paper{
+			ID:            response.PaperID,
+			UserID:        "test_user_1",
+			ConferenceID:  1,
+			Title:         "Can anyone code?",
+			ElevatorPitch: "Is anyone capeable of coding? Lets discuss",
+			Description:   "What does it require for someone to learn to code? Intelligence? Mindset?",
+			Notes:         "Target Audience: Anyone!",
+		}
+
+		result, err := UpdatePaper(ctx, &UpdatePaperParams{Paper: updatedPaper})
+
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		if result.Paper.UserID != originalPaper.UserID {
+			t.Errorf("UserID was unexpectedly updated got %v want %v", result.Paper.UserID, originalPaper.UserID)
+		}
+
+		if result.Paper.Title == originalPaper.Title {
+			t.Errorf("title was not updated got %v want %v", result.Paper.UserID, originalPaper.UserID)
+		}
+
+		if result.Paper.ElevatorPitch == originalPaper.ElevatorPitch {
+			t.Errorf("elevator pitch was not updated got %v want %v", result.Paper.ElevatorPitch, originalPaper.ElevatorPitch)
+		}
+
+		if result.Paper.Description == originalPaper.Description {
+			t.Errorf("description was not updated got %v want %v", result.Paper.Description, originalPaper.Description)
+		}
+
+		if result.Paper.Notes == originalPaper.Notes {
+			t.Errorf("notes was not updated got %v want %v", result.Paper.Notes, originalPaper.Notes)
+		}
+	})
+}

--- a/conferences/updatepaper_test.go
+++ b/conferences/updatepaper_test.go
@@ -63,4 +63,58 @@ func TestUpdatePaperSubmission(t *testing.T) {
 			t.Errorf("notes was not updated got %v want %v", result.Paper.Notes, originalPaper.Notes)
 		}
 	})
+
+	t.Run("checks a user can update some of their proposal", func(t *testing.T) {
+
+		originalPaper := &Paper{
+			UserID:        "test_user_2",
+			ConferenceID:  2,
+			Title:         "Go ahead with Go",
+			ElevatorPitch: "Why you should code in Go",
+			Description:   "Because the mascot is the best",
+			Notes:         "It comes in all shapes and sizes",
+		}
+
+		ctx := context.Background()
+		_, err := AddPaper(ctx, &AddPaperParams{
+			Paper: originalPaper,
+		},
+		)
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		updatedPaper := *originalPaper
+
+		updatedPaper.Title = "Get Great with Go"
+		updatedPaper.Notes = "Target audience: New Gophers"
+
+		result, err := UpdatePaper(ctx, &UpdatePaperParams{Paper: &updatedPaper})
+
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		if result.Paper.UserID != originalPaper.UserID {
+			t.Errorf("UserID was unexpectedly updated got %v want %v", result.Paper.UserID, originalPaper.UserID)
+		}
+
+		if result.Paper.Title == originalPaper.Title {
+			t.Errorf("title was not updated got %v want %v", result.Paper.UserID, originalPaper.UserID)
+		}
+
+		if result.Paper.ElevatorPitch != originalPaper.ElevatorPitch {
+			t.Errorf("elevator pitch was not updated got %v want %v", result.Paper.ElevatorPitch, originalPaper.ElevatorPitch)
+		}
+
+		if result.Paper.Description != originalPaper.Description {
+			t.Errorf("description was not updated got %v want %v", result.Paper.Description, originalPaper.Description)
+		}
+
+		if result.Paper.Notes == originalPaper.Notes {
+			t.Errorf("notes was not updated got %v want %v", result.Paper.Notes, originalPaper.Notes)
+		}
+
+	})
+
 }

--- a/conferences/updatepaper_test.go
+++ b/conferences/updatepaper_test.go
@@ -76,7 +76,7 @@ func TestUpdatePaperSubmission(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		_, err := AddPaper(ctx, &AddPaperParams{
+		response, err := AddPaper(ctx, &AddPaperParams{
 			Paper: originalPaper,
 		},
 		)
@@ -86,6 +86,7 @@ func TestUpdatePaperSubmission(t *testing.T) {
 
 		updatedPaper := *originalPaper
 
+		updatedPaper.ID = response.PaperID
 		updatedPaper.Title = "Get Great with Go"
 		updatedPaper.Notes = "Target audience: New Gophers"
 
@@ -114,7 +115,5 @@ func TestUpdatePaperSubmission(t *testing.T) {
 		if result.Paper.Notes == originalPaper.Notes {
 			t.Errorf("notes was not updated got %v want %v", result.Paper.Notes, originalPaper.Notes)
 		}
-
 	})
-
 }


### PR DESCRIPTION
Added a method that allows basic updating of a paper submission.

Updated some spelling issues.

Added defer row.Close() in pre-exisiting tests. 

This PR does not fix testing issue discussed in gc-manager.