### PR TITLE
CFP Submissions Delete Method

### DIFF
--- a/conferences/deletepaper.go
+++ b/conferences/deletepaper.go
@@ -1,0 +1,34 @@
+package conferences
+
+import (
+	"context"
+	"fmt"
+
+	"encore.dev/storage/sqldb"
+)
+
+// DeletePaperParams defines the inputs used by the DeletePaper API method
+type DeletePaperParams struct {
+	PaperID uint32
+}
+
+// DeletePaper removes a specific paper from the db
+//encore:api public
+func DeletePaper(ctx context.Context, params *DeletePaperParams) error {
+
+	result, err := sqldb.Exec(ctx,
+		`DELETE FROM paper_submission WHERE id = $1`, params.PaperID)
+	if err != nil {
+		return fmt.Errorf("failed to delete paper: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("error getting rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("could not find paper with id %v", params.PaperID)
+	}
+	return nil
+}

--- a/conferences/deletepaper_test.go
+++ b/conferences/deletepaper_test.go
@@ -1,0 +1,47 @@
+package conferences
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDeletePaper(t *testing.T) {
+
+	t.Run("user can delete a specific paper that they have submitted", func(t *testing.T) {
+
+		paper := &Paper{
+			UserID:        "test_user_1",
+			ConferenceID:  1,
+			Title:         "Test title",
+			ElevatorPitch: "Elevating elevator pitch",
+			Description:   "Descriptive description",
+			Notes:         "Notable Notes",
+		}
+
+		ctx := context.Background()
+		response, err := AddPaper(ctx, &AddPaperParams{
+			Paper: paper,
+		},
+		)
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		err = DeletePaper(ctx, &DeletePaperParams{
+			PaperID: response.PaperID,
+		})
+
+		if err != nil {
+			t.Errorf("paper was not deleted: %w", err)
+		}
+	})
+
+	t.Run("checks that an error is returned if a delete is attempted on a paperid that does not exist", func(t *testing.T) {
+
+		ctx := context.Background()
+		err := DeletePaper(ctx, &DeletePaperParams{PaperID: 0})
+		if err == nil {
+			t.Errorf("paper that does not exist was deleted")
+		}
+	})
+}


### PR DESCRIPTION
Simple delete method for a specific id in the paper_submissions table.


Based off of `cps-submissions-edit`

