### PR TITLE
CFP List Anon Papers

### DIFF
--- a/conferences/listanonpapers.go
+++ b/conferences/listanonpapers.go
@@ -1,0 +1,64 @@
+package conferences
+
+import (
+	"context"
+	"fmt"
+
+	"encore.dev/storage/sqldb"
+)
+
+// ListAnonPapersParams defines the inputs used by the ListAnonPapers API method
+type ListAnonPapersParams struct {
+	ConferenceID uint32
+}
+
+// ListAnonPapersResponse defines the output returned by the ListAnonPapers API method
+type ListAnonPapersResponse struct {
+	AnonPapers []AnonPaper
+}
+
+// ListAnonPapers retrieves all the papers
+// submitted for a specific conference without
+// user identification information
+// encore:api public
+func ListAnonPapers(ctx context.Context, params *ListAnonPapersParams) (*ListAnonPapersResponse, error) {
+
+	rows, err := sqldb.Query(ctx,
+		` SELECT id,
+			conference_id,
+			title,
+			elevator_pitch,
+			description,
+			notes
+			FROM paper_submission
+			ORDER BY id
+`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve all papers: %w", err)
+	}
+
+	defer rows.Close()
+
+	var anonPapers []AnonPaper
+
+	for rows.Next() {
+
+		var anonPaper AnonPaper
+
+		err := rows.Scan(
+			&anonPaper.ID,
+			&anonPaper.ConferenceID,
+			&anonPaper.Title,
+			&anonPaper.ElevatorPitch,
+			&anonPaper.Description,
+			&anonPaper.Notes,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan rows: %w", err)
+		}
+
+		anonPapers = append(anonPapers, anonPaper)
+	}
+
+	return &ListAnonPapersResponse{AnonPapers: anonPapers}, nil
+}

--- a/conferences/listanonpapers_test.go
+++ b/conferences/listanonpapers_test.go
@@ -1,0 +1,56 @@
+package conferences
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListAnonPapers(t *testing.T) {
+
+	t.Run("returns all papers without identifying information", func(t *testing.T) {
+
+		paper := &Paper{
+			UserID:        "test_user_1",
+			ConferenceID:  1,
+			Title:         "Test title",
+			ElevatorPitch: "Elevating elevator pitch",
+			Description:   "Descriptive description",
+			Notes:         "Notable Notes",
+		}
+
+		ctx := context.Background()
+		_, err := AddPaper(ctx, &AddPaperParams{
+			Paper: paper,
+		},
+		)
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		result, err := ListAnonPapers(ctx,
+			&ListAnonPapersParams{ConferenceID: paper.ConferenceID},
+		)
+		if err != nil {
+			t.Fatalf("failed retrieve papers: %v", err)
+		}
+
+		resultLength := len(result.AnonPapers) - 1
+
+		if result.AnonPapers[resultLength].Title != paper.Title {
+			t.Errorf("title was not as expected got %v want %v", result.AnonPapers[resultLength].Title, paper.Title)
+		}
+
+		if result.AnonPapers[resultLength].ElevatorPitch != paper.ElevatorPitch {
+			t.Errorf("elevator pitch was not as expected got %v want %v", result.AnonPapers[resultLength].ElevatorPitch, paper.ElevatorPitch)
+		}
+
+		if result.AnonPapers[resultLength].Description != paper.Description {
+			t.Errorf("elevator pitch was not as expected got %v want %v", result.AnonPapers[resultLength].Description, paper.Description)
+		}
+
+		if result.AnonPapers[resultLength].Notes != paper.Notes {
+			t.Errorf("elevator pitch was not as expected got %v want %v", result.AnonPapers[resultLength].Notes, paper.Notes)
+		}
+
+	})
+}

--- a/conferences/papertypes.go
+++ b/conferences/papertypes.go
@@ -10,3 +10,14 @@ type Paper struct {
 	Description   string
 	Notes         string
 }
+
+// AnonPaper holds information about a paper
+// without anything that identifies the user
+type AnonPaper struct {
+	ID            uint32
+	ConferenceID  uint32
+	Title         string
+	ElevatorPitch string
+	Description   string
+	Notes         string
+}


### PR DESCRIPTION
After discussions in discord, it is noted that reviewers of papers in the initial phases of reviews do not 
get access to user identifiying information.

ListAnonPapers returns all papers without currently available user identifying information (UserID at present).

This method would be intended to be used on the reviewer side of the site. 

Based off of `cfp-submissions-delete`