### PR TITLE
CFP Reviewers GetAnonPaper

### DIFF
--- a/conferences/anonpaperroundtrip_test.go
+++ b/conferences/anonpaperroundtrip_test.go
@@ -1,0 +1,54 @@
+package conferences
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetAnonPaperRoundTrip(t *testing.T) {
+
+	t.Run("adds a paper for a specific conference", func(t *testing.T) {
+
+		paper := &Paper{
+			UserID:        "test_user_1",
+			ConferenceID:  1,
+			Title:         "Test title",
+			ElevatorPitch: "Elevating elevator pitch",
+			Description:   "Descriptive description",
+			Notes:         "Notable Notes",
+		}
+
+		ctx := context.Background()
+		response, err := AddPaper(ctx, &AddPaperParams{
+			Paper: paper,
+		},
+		)
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		result, err := GetAnonPaper(ctx, &GetAnonPaperParams{PaperID: response.PaperID})
+
+		if err != nil {
+			t.Fatalf("unexpected database error: %v", err)
+		}
+
+		if result.AnonPaper.Title != paper.Title {
+			t.Errorf("incorrect title returned got %v want %v", result.AnonPaper.Title, paper.UserID)
+		}
+
+		if result.AnonPaper.ElevatorPitch != paper.ElevatorPitch {
+			t.Errorf("incorrect elevator pitch returned got %v want %v", result.AnonPaper.ElevatorPitch, paper.ElevatorPitch)
+		}
+
+		if result.AnonPaper.Description != paper.Description {
+			t.Errorf("incorrect description returned got %v want %v", result.AnonPaper.Description, paper.Description)
+		}
+
+		if result.AnonPaper.Notes != paper.Notes {
+			t.Errorf("incorrect notes returned got %v want %v", result.AnonPaper.Notes, paper.Notes)
+		}
+
+	})
+
+}

--- a/conferences/getanonpaper.go
+++ b/conferences/getanonpaper.go
@@ -1,0 +1,57 @@
+package conferences
+
+import (
+	"context"
+	"fmt"
+
+	"encore.dev/storage/sqldb"
+)
+
+// GetAnonPaperParams defines the inputs used by the GetAnonPaper API method
+type GetAnonPaperParams struct {
+	PaperID uint32
+}
+
+// GetAnonPaperResponse defines the output returned by the GetAnonPaper API method
+type GetAnonPaperResponse struct {
+	AnonPaper AnonPaper
+}
+
+// GetAnonPaper retrieves information for a
+// specific paper id without identifying
+// user info
+// encore:api public
+func GetAnonPaper(ctx context.Context, params *GetAnonPaperParams) (*GetAnonPaperResponse, error) {
+
+	row := sqldb.QueryRow(
+		ctx,
+		`
+		SELECT id,
+		conference_id,
+		title,
+		elevator_pitch,
+		description,
+		notes
+		FROM paper_submission
+		WHERE id = $1
+		`, params.PaperID,
+	)
+
+	var anonPaper AnonPaper
+
+	err := row.Scan(
+		&anonPaper.ID,
+		&anonPaper.ConferenceID,
+		&anonPaper.Title,
+		&anonPaper.ElevatorPitch,
+		&anonPaper.Description,
+		&anonPaper.Notes,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve paper: %w", err)
+	}
+
+	return &GetAnonPaperResponse{AnonPaper: anonPaper}, nil
+
+}

--- a/conferences/papersubmission_test.go
+++ b/conferences/papersubmission_test.go
@@ -38,7 +38,7 @@ func TestAddPaperRoundTrip(t *testing.T) {
 		}
 
 		if result.Paper.Title != paper.Title {
-			t.Errorf("incorrect title returned got %v want %v", result.Paper.UserID, paper.UserID)
+			t.Errorf("incorrect title returned got %v want %v", result.Paper.Title, paper.Title)
 		}
 
 		if result.Paper.ElevatorPitch != paper.ElevatorPitch {


### PR DESCRIPTION
Retrieves a single paper by PaperID without user information.

Updated a test where a got/want expectation was set to UserID rather than title. 

Based off of `cfp-reviewers-get`